### PR TITLE
Fix angled name issue

### DIFF
--- a/gurpsspace/asteroidbelt.py
+++ b/gurpsspace/asteroidbelt.py
@@ -19,7 +19,7 @@ class AsteroidBelt(OrbitContent):
         return "Ast. Belt"
 
     def print_info(self):
-        print("Asteroid Belt {}".format(self.get_name()))
+        print("Asteroid Belt {}".format(self.get_angled_name()))
         print("    Orbit:\t{}".format(self.get_orbit()))
         print("  Orb Per:\t{}".format(self.get_period()))
         print("  Orb Ecc:\t{}".format(self.get_eccentricity()))

--- a/gurpsspace/gasgiant.py
+++ b/gurpsspace/gasgiant.py
@@ -32,7 +32,7 @@ class GasGiant(OrbitContent):
         return self.__size
 
     def print_info(self):
-        print("---- Gas Giant {} Properties ----".format(self.get_name()))
+        print("---- Gas Giant {} Properties ----".format(self.get_angled_name()))
         print("     Size:\t{}".format(self.__size))
         print("  BB Temp:\t{}".format(self.get_blackbody_temp()))
         print("     Mass:\t{}".format(self.__mass))
@@ -137,7 +137,7 @@ class GasGiant(OrbitContent):
             counter += 1
             moon.set_number(counter)
             letter = self.primary_star.get_letter()
-            name = '<{}-{}-{}>'.format(letter, number, counter)
+            name = '{}-{}-{}'.format(letter, number, counter)
             moon.set_name(name)
 
     def get_moons(self):

--- a/gurpsspace/orbitcontents.py
+++ b/gurpsspace/orbitcontents.py
@@ -79,6 +79,9 @@ class OrbitContent:
     def get_name(self):
         return self.__name
 
+    def get_angled_name(self):
+        return "<" + self.__name + ">"
+
     def set_number(self, number):
         self.__number = number
 

--- a/gurpsspace/planet.py
+++ b/gurpsspace/planet.py
@@ -18,7 +18,7 @@ class Planet(World):
         self.make_axial_tilt()
 
     def print_info(self):
-        print("--- Planet {} Info ---".format(self.get_name()))
+        print("--- Planet {} Info ---".format(self.get_angled_name()))
         print("        Orbit:\t{}".format(self.get_orbit()))
         print("   World Type:\t{} ({})".format(self.get_size(), self.get_type()))
         if self.__nummoons > 0:
@@ -259,5 +259,5 @@ class Planet(World):
             counter += 1
             moon.set_number(counter)
             letter = self.primary_star.get_letter()
-            name = '<{}-{}-{}>'.format(letter, number, counter)
+            name = '{}-{}-{}'.format(letter, number, counter)
             moon.set_name(name)

--- a/gurpsspace/planetsystem.py
+++ b/gurpsspace/planetsystem.py
@@ -264,7 +264,7 @@ class PlanetSystem:
         counter = 0
         for key in sorted(self.__orbitcontents):
             counter += 1
-            name = '<{}-{}>'.format(self.parentstar.get_letter(), counter)
+            name = '{}-{}'.format(self.parentstar.get_letter(), counter)
             self.__orbitcontents[key].set_name(name)
             self.__orbitcontents[key].set_number(counter)
 

--- a/gurpsspace/satellites.py
+++ b/gurpsspace/satellites.py
@@ -32,7 +32,7 @@ class Moon(World):
         self.make_calendar()
 
     def print_info(self):
-        print("         *** Moon {} Information *** ".format(self.get_name()))
+        print("         *** Moon {} Information *** ".format(self.get_angled_name()))
         # print("Parent Planet:\t{}".format(self.parent))
         print("           World Type:\t{} ({})".format(self.__sizeclass, self.get_type()))
         print("                Orbit:\t{} Earth Diameters".format(self.__orbit))
@@ -209,6 +209,9 @@ class Moon(World):
 
     def get_name(self):
         return self.__name
+
+    def get_angled_name(self):
+        return "<" + self.__name + ">"
 
     def set_number(self, number):
         self.__number = number

--- a/webgui/server.py
+++ b/webgui/server.py
@@ -81,13 +81,13 @@ class WebServer(object):
                 if starsystem.stars[star_id].planetsystem.get_orbitcontents()[key].type() == 'Ast. Belt':
                     a_count += 1
                 if namegen is not None:
-                    simple_name = v.get_angled_name().replace("<", "").replace(">", "").replace("-", "")
+                    simple_name = v.get_name().replace("-", "")
                     if cherrypy.session.get('name_of_' + simple_name) is None:
                         name = namegen.get_random_name()
                         starsystem.stars[star_id].planetsystem.get_orbitcontents()[key].set_name(name)
                         # For some reason, using simple_name here leads to storing stuff improperly and
                         # generating new names every time. No idea why.
-                        cherrypy.session['name_of_' + v.get_angled_name().replace("<", "").replace(">", "").replace("-", "")] = name
+                        cherrypy.session['name_of_' + v.get_name().replace("-", "")] = name
                     else:
                         name = cherrypy.session.get('name_of_' + simple_name)
                         starsystem.stars[star_id].planetsystem.get_orbitcontents()[key].set_name(name)
@@ -120,7 +120,7 @@ class WebServer(object):
         cherrypy.session['moons'] = moons
 
         tmpl = env.get_template('moons.html')
-        return tmpl.render(moons=moons, planet_name=planet.get_angled_name().replace("<", "").replace(">", ""))
+        return tmpl.render(moons=moons, planet_name=planet.get_name())
 
     def translate_row(self, planet, row):
         """
@@ -131,7 +131,7 @@ class WebServer(object):
         :return: The  data appropriate to the given row.
         """
         if row == '':
-            return planet.get_angled_name().replace("<", "").replace(">", "")
+            return planet.get_name()
         if row == 'World Size':
             return planet.get_size()
         if row == 'World Type':

--- a/webgui/server.py
+++ b/webgui/server.py
@@ -81,13 +81,13 @@ class WebServer(object):
                 if starsystem.stars[star_id].planetsystem.get_orbitcontents()[key].type() == 'Ast. Belt':
                     a_count += 1
                 if namegen is not None:
-                    simple_name = v.get_name().replace("<", "").replace(">", "").replace("-", "")
+                    simple_name = v.get_angled_name().replace("<", "").replace(">", "").replace("-", "")
                     if cherrypy.session.get('name_of_' + simple_name) is None:
                         name = namegen.get_random_name()
                         starsystem.stars[star_id].planetsystem.get_orbitcontents()[key].set_name(name)
                         # For some reason, using simple_name here leads to storing stuff improperly and
                         # generating new names every time. No idea why.
-                        cherrypy.session['name_of_' + v.get_name().replace("<", "").replace(">", "").replace("-", "")] = name
+                        cherrypy.session['name_of_' + v.get_angled_name().replace("<", "").replace(">", "").replace("-", "")] = name
                     else:
                         name = cherrypy.session.get('name_of_' + simple_name)
                         starsystem.stars[star_id].planetsystem.get_orbitcontents()[key].set_name(name)
@@ -120,7 +120,7 @@ class WebServer(object):
         cherrypy.session['moons'] = moons
 
         tmpl = env.get_template('moons.html')
-        return tmpl.render(moons=moons, planet_name=planet.get_name().replace("<", "").replace(">", ""))
+        return tmpl.render(moons=moons, planet_name=planet.get_angled_name().replace("<", "").replace(">", ""))
 
     def translate_row(self, planet, row):
         """
@@ -131,7 +131,7 @@ class WebServer(object):
         :return: The  data appropriate to the given row.
         """
         if row == '':
-            return planet.get_name().replace("<", "").replace(">", "")
+            return planet.get_angled_name().replace("<", "").replace(">", "")
         if row == 'World Size':
             return planet.get_size()
         if row == 'World Type':

--- a/webgui/templates/planetsystem.html
+++ b/webgui/templates/planetsystem.html
@@ -39,7 +39,7 @@
         {% for key, planet in planetsystem.get_orbitcontents().items()|sort %}
         {% set astro_body = planetsystem.get_orbitcontents()[key] %}
         <tr>
-            <td>{{astro_body.get_angled_name().replace("<", "").replace(">","")|e}}</td>
+            <td>{{astro_body.get_name()|e}}</td>
             <td>{{astro_body.type()}}</td>
             <td>{% if astro_body.get_size() != '' %}{{astro_body.get_size()}}{% else %} N/A {% endif %}</td>
             <td>{% if astro_body.get_type() != '' %}{{astro_body.get_type()}}{% else %} N/A {% endif %}</td>
@@ -85,7 +85,7 @@
         {% for key, _ in planetsystem.get_orbitcontents().items()|sort if planetsystem.get_orbitcontents()[key].type() == 'Ast. Belt'%}
         {% set astro_body = planetsystem.get_orbitcontents()[key] %}
         <tr>
-            <td>{{astro_body.get_angled_name().replace("<", "").replace(">","")|e}}</td>
+            <td>{{astro_body.get_name()|e}}</td>
             <td>{{astro_body.get_average_surface_temp()|round(2)}} K / {{(astro_body.get_average_surface_temp()-273.15)|round(2)}}°C</td>
             <td>{{astro_body.get_climate()}}</td>
             <td>{{astro_body.get_rvm()}}</td>

--- a/webgui/templates/planetsystem.html
+++ b/webgui/templates/planetsystem.html
@@ -39,7 +39,7 @@
         {% for key, planet in planetsystem.get_orbitcontents().items()|sort %}
         {% set astro_body = planetsystem.get_orbitcontents()[key] %}
         <tr>
-            <td>{{astro_body.get_name().replace("<", "").replace(">","")|e}}</td>
+            <td>{{astro_body.get_angled_name().replace("<", "").replace(">","")|e}}</td>
             <td>{{astro_body.type()}}</td>
             <td>{% if astro_body.get_size() != '' %}{{astro_body.get_size()}}{% else %} N/A {% endif %}</td>
             <td>{% if astro_body.get_type() != '' %}{{astro_body.get_type()}}{% else %} N/A {% endif %}</td>
@@ -85,7 +85,7 @@
         {% for key, _ in planetsystem.get_orbitcontents().items()|sort if planetsystem.get_orbitcontents()[key].type() == 'Ast. Belt'%}
         {% set astro_body = planetsystem.get_orbitcontents()[key] %}
         <tr>
-            <td>{{astro_body.get_name().replace("<", "").replace(">","")|e}}</td>
+            <td>{{astro_body.get_angled_name().replace("<", "").replace(">","")|e}}</td>
             <td>{{astro_body.get_average_surface_temp()|round(2)}} K / {{(astro_body.get_average_surface_temp()-273.15)|round(2)}}°C</td>
             <td>{{astro_body.get_climate()}}</td>
             <td>{{astro_body.get_rvm()}}</td>


### PR DESCRIPTION
With this pull request the type of decorator around the name of the orbiting body, be it moon, planet, or gas giant, is no longer hardcoded to be `<...>`.

This simplifies the processing of the names, especially in the server application.

Merging this pull request will fix #34.